### PR TITLE
tests: add pytest compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setuptools.setup(
 	},
 	# download_url="",
 
-	packages=setuptools.find_packages(),
+	packages=setuptools.find_packages(exclude=["tests", "tests.*"]),
 	classifiers=[
 		"License :: OSI Approved :: Apache Software License",
 		"Operating System :: OS Independent",

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = *


### PR DESCRIPTION
cf. VHDL/pyVHDLModel#12. To make the project compatible with running pytest on the not-yet-installed sources,
1. pytest has to be told not to care about filenames of tests,
2. because `import pyMetaClasses` in the tests has to resolve to the root `pyMetaClass/` directory, the `tests/` directory has to be a module, not only `tests/unit/`.